### PR TITLE
updated to keep only WormBase entries

### DIFF
--- a/modules/annotation.module.nf
+++ b/modules/annotation.module.nf
@@ -68,7 +68,7 @@ process format_csq {
     '''
         # to prep the gff3 for bcftools csq
         gzip -dc in.gff.gz | \
-            awk '$2 ~ "WormBase.*"' | \
+            awk '$2 ~ "WormBase"' | \
             sed -e 's/ID=Transcript:/ID=transcript:/g' \
                 -e 's/ID=Gene:/ID=gene:/g' \
                 -e 's/Parent=Transcript:/Parent=transcript:/g' \


### PR DESCRIPTION
Keep only entries from `WormBase` instead of `WormBase*`, which will include `WormBase_transposon`, which is the cause for error later in wi-gatk csq annotation gff.
I will remove the following from wi-gatk accordingly:
```
        # Remove transposons from GFF3 as they throw errors with CSQ
        gzip -dc ${file(params.csq_gff, checkIfExists: true)} | grep -v 'transposon' | bgzip > csq.gff.gz
        tabix -p gff csq.gff.gz
```